### PR TITLE
Can optionally force content into the blob regardless of size

### DIFF
--- a/src/SimpleAzure.Storage.HybridQueue.Tests/IntegrationTests/AddMessageAsyncTests/AddMessageAsyncTests.cs
+++ b/src/SimpleAzure.Storage.HybridQueue.Tests/IntegrationTests/AddMessageAsyncTests/AddMessageAsyncTests.cs
@@ -21,6 +21,22 @@ public class AddMessageAsyncTests : CustomAzuriteTestContainer
     }
 
     [Fact]
+    public async Task AddMessageAsync_GivenSomeSimpleStringAndFocedOntoTheBlob_ShouldAddTheMessageToTheBlobAndQueue()
+    {
+        // Arrange.
+        var cancellationToken = CancellationToken.None;
+        var message = "hello";
+
+        // Act.
+        await HybridQueue.AddMessageAsync(message, null, true, cancellationToken);
+
+        // Assert.
+        var retrievedMessage = await HybridQueue.GetMessageAsync<string>(cancellationToken);
+        retrievedMessage.ShouldNotBeNull();
+        retrievedMessage.Content.ShouldBe(message);
+    }
+
+    [Fact]
     public async Task AddMessageAsync_GivenASimpleInt_ShouldAddTheMessageToTheQueue()
     {
         // Arrange.

--- a/src/SimpleAzure.Storage.HybridQueue.Tests/IntegrationTests/AddMessagesAsyncTests/AddMessagesAsyncTests.cs
+++ b/src/SimpleAzure.Storage.HybridQueue.Tests/IntegrationTests/AddMessagesAsyncTests/AddMessagesAsyncTests.cs
@@ -26,6 +26,27 @@ public class AddMessagesAsyncTests : CustomAzuriteTestContainer
     }
 
     [Fact]
+    public async Task AddMessagesAsync_GivenSomeSimpleStringsAndForcedOntoTheBlob_ShouldAddThemAllToTheBlobAndQueue()
+    {
+        // Arrange.
+        var cancellationToken = CancellationToken.None;
+        var messages = new[] { "aaa", "bbb", "ccc", "ddd" };
+
+        // Act.
+        await HybridQueue.AddMessagesAsync(messages, null, 10, true, cancellationToken);
+
+        // Assert.
+        var retrievedMessage = await HybridQueue.GetMessagesAsync<string>(cancellationToken);
+        retrievedMessage.ShouldNotBeNull();
+
+        retrievedMessage
+            .Select(hm => hm.Content)
+            .ToArray()
+            .OrderBy(s => s)
+            .ShouldBeEquivalentTo(messages.OrderBy(s => s));
+    }
+
+    [Fact]
     public async Task AddMessagesAsync_GivenSomeComplexInstances_ShouldAddThemAllToTheQueue()
     {
         // Arrange.

--- a/src/SimpleAzure.Storage.HybridQueue/IHybridQueue.cs
+++ b/src/SimpleAzure.Storage.HybridQueue/IHybridQueue.cs
@@ -3,27 +3,30 @@ namespace WorldDomination.SimpleAzure.Storage.HybridQueues;
 public interface IHybridQueue
 {
     /// <summary>
-    /// Initiates an asynchronous operation to add an item to the queue.
+    /// Initiates an asynchronous operation to add an item to the queue and potentially the backing blob.
     /// </summary>
     /// <typeparam name="T">Type of item.</typeparam>
     /// <param name="item">An item to add to the queue.</param>
     /// <param name="initialVisibilityDelay">How long to initially hide the message.</param>
+    /// <param name="isForcedOntoBlob">The item is placed on the blob regardless of the item's size.</param>
     /// <param name="cancellationToken">A System.Threading.CancellationToken to observe while waiting for a task to complete.</param>
     /// <returns>A System.Threading.Tasks.Task object that represents the asynchronous operation.</returns>
     /// <remarks>If the item is a IsPrimitive (int, etc) or a string then it's stored -as is-. Otherwise, it is serialized to Json and then stored as Json.(</remarks>
     Task AddMessageAsync<T>(
         T item,
         TimeSpan? initialVisibilityDelay,
+        bool isForcedOntoBlob,
         CancellationToken cancellationToken);
 
 
     /// <summary>
-    /// Initiates an asynchronous operation to add a batch messages to the queue.
+    /// Initiates an asynchronous operation to add a batch of messages to the queue and potentially the backing blob.
     /// </summary>
     /// <typeparam name="T">Type of item.</typeparam>
     /// <param name="contents">Collection of content to add to the queue.</param>
     /// <param name="initialVisibilityDelay">How long to initially hide the message.</param>
     /// <param name="batchSize">Number of messages per batch, to store as one parallel execution.</param>
+    /// <param name="isForcedOntoBlob">The item is placed on the blob regardless of the item's size.</param>
     /// <param name="cancellationToken">A System.Threading.CancellationToken to observe while waiting for a task to complete.</param>
     /// <returns>A System.Threading.Tasks.Task object that represents the asynchronous operation.</returns>
     /// <remarks>If any item is a IsPrimitive (int, etc) or a string then it's stored -as is-. Otherwise, it is serialized to Json and then stored as Json.(</remarks>
@@ -31,6 +34,7 @@ public interface IHybridQueue
         IEnumerable<T> contents,
         TimeSpan? initialVisibilityDelay,
         int batchSize,
+        bool isForcedOntoBlob,
         CancellationToken cancellationToken);
 
     /// <summary>
@@ -42,7 +46,7 @@ public interface IHybridQueue
     Task DeleteMessageAsync<T>(HybridMessage<T> hybridMessage, CancellationToken cancellationToken);
 
     /// <summary>
-    /// Retrieves a message from a queue and wraps it in a simple Message class.
+    /// Retrieves a message from a queue and potentially the backing blob. It will then wrap it in a simple Message class.
     /// </summary>
     /// <typeparam name="T">Type of item.</typeparam>
     /// <param name="visibilityTimeout">A System.TimeSpan specifying the visibility timeout interval.</param>

--- a/src/SimpleAzure.Storage.HybridQueue/IHybridQueueExtensions.cs
+++ b/src/SimpleAzure.Storage.HybridQueue/IHybridQueueExtensions.cs
@@ -3,19 +3,19 @@ namespace WorldDomination.SimpleAzure.Storage.HybridQueues;
 public static class IHybridQueueExtensions
 {
     /// <summary>
-    /// Initiates an asynchronous operation to add an item to the queue.
+    /// Initiates an asynchronous operation to add an item to the queue and potentially the backing blob.
     /// </summary>
     /// <typeparam name="T">Type of item.</typeparam>
-    /// <param name="queue">The queue to operate on</param>
+    /// <param name="queue">The queue to operate on.</param>
     /// <param name="item">An item to add to the queue.</param>
     /// <param name="cancellationToken">A System.Threading.CancellationToken to observe while waiting for a task to complete.</param>
     /// <returns>A System.Threading.Tasks.Task object that represents the asynchronous operation.</returns>
     /// <remarks>If the item is a IsPrimitive (int, etc) or a string then it's stored -as is-. Otherwise, it is serialized to Json and then stored as Json.(</remarks>
     public static Task AddMessageAsync<T>(this IHybridQueue queue, T item, CancellationToken cancellationToken) =>
-        queue.AddMessageAsync(item, null, cancellationToken);
+        queue.AddMessageAsync(item, null, false, cancellationToken);
 
     /// <summary>
-    /// Initiates an asynchronous operation to add a batch messages to the queue.
+    /// Initiates an asynchronous operation to add a batch of messages to the queue and potentially the backing blob.
     /// </summary>
     /// <typeparam name="T">Type of item.</typeparam>
     /// <param name="queue">The queue to operate on</param>
@@ -24,10 +24,10 @@ public static class IHybridQueueExtensions
     /// <returns>A System.Threading.Tasks.Task object that represents the asynchronous operation.</returns>
     /// <remarks>If any item is a IsPrimitive (int, etc) or a string then it's stored -as is-. Otherwise, it is serialized to Json and then stored as Json.(</remarks>
     public static Task AddMessagesAsync<T>(this IHybridQueue queue, IEnumerable<T> contents, CancellationToken cancellationToken) =>
-        queue.AddMessagesAsync(contents, null, 25, cancellationToken);
+        queue.AddMessagesAsync(contents, null, 25, false, cancellationToken);
 
     /// <summary>
-    /// Retrieves a message from a queue and wraps it in a simple Message class.
+    /// Retrieves a message from a queue and potentially the backing blob. It will then wrap it in a simple Message class.
     /// </summary>
     /// <typeparam name="T">Type of item.</typeparam>
     /// <param name="queue">The queue to operate on</param>


### PR DESCRIPTION
Allow's you to optionally force the content onto the blob and queue, not just based on the _size_ of the content.

The default logic is to only use the blob -if- the content is "too large".