### PR TITLE
Expose ParseMessageAsync as a public method

### DIFF
--- a/src/SimpleAzure.Storage.HybridQueues/IHybridQueue.cs
+++ b/src/SimpleAzure.Storage.HybridQueues/IHybridQueue.cs
@@ -1,3 +1,5 @@
+using Azure.Storage.Queues.Models;
+
 namespace WorldDomination.SimpleAzure.Storage.HybridQueues;
 
 public interface IHybridQueue
@@ -68,4 +70,13 @@ public interface IHybridQueue
         int maxMessages,
         TimeSpan? visibilityTimeout,
         CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Parses a QueueMessage into a HybridMessage with the smarts of retreiving the data from a blob, if required.
+    /// </summary>
+    /// <typeparam name="T">Type of item.</typeparam>
+    /// <param name="queueMessage">Azure Storage QueueMessage.</param>
+    /// <param name="cancellationToken">A System.Threading.CancellationToken to observe while waiting for a task to complete.</param>
+    /// <returns>A HybridMessage with the relevant message content and extra Azure Storage Queue/Blob meta data.</returns>
+    Task<HybridMessage<T>> ParseMessageAsync<T>(QueueMessage queueMessage, CancellationToken cancellationToken);
 }


### PR DESCRIPTION
For frameworks like Azure Functions which _automatically poll and pop_ messages from a Queue, we need the ability to parse the "Hybrid" message.

As such, we can leverage all the smarts which we have in this codebase, but are `private`. By exposing them as `public` we can now have the best of both worlds