### PR TITLE
🚮 Remove hardcoded version from NuGet package

### DIFF
--- a/src/SimpleAzure.Storage.HybridQueues/SimpleAzure.Storage.HybridQueues.csproj
+++ b/src/SimpleAzure.Storage.HybridQueues/SimpleAzure.Storage.HybridQueues.csproj
@@ -6,7 +6,6 @@
     <Nullable>enable</Nullable>
     <AssemblyName>WorldDomination.$(MSBuildProjectName)</AssemblyName>
     <RootNamespace>WorldDomination.$(MSBuildProjectName.Replace(" ", "_"))</RootNamespace>
-    <Version>0.1.0</Version>
     <Title>Simple: Azure Storage Hybrid Queues</Title>
     <Company>World Domination Technolgoies Pty. Ltd.</Company>
     <Authors>Justin Adler</Authors>


### PR DESCRIPTION
Recently, I added in the version "hardcoded" in the csproj file. This was taking precedence over the values provided via the CLI.

As such, this PR removes that restriction.